### PR TITLE
Refactor ast inspection function into a closure

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -37,7 +37,15 @@ func Debug(value any) {
 		return
 	}
 
-	ast.Inspect(f, func(node ast.Node) bool {
+	ast.Inspect(f, findAndDebug(fset, line, value))
+}
+
+// findAndDebug is an AST traversal function to be passed to [go/ast.Inspect]
+// and will find calls to debug.Debug, and print the debugging information.
+//
+// It returns a closure that can be passed directly to [go/ast.Inspect].
+func findAndDebug(fset *token.FileSet, line int, value any) func(node ast.Node) bool {
+	return func(node ast.Node) bool {
 		if node == nil {
 			return false
 		}
@@ -83,7 +91,7 @@ func Debug(value any) {
 		}
 
 		return false // Found it
-	})
+	}
 }
 
 // isDebugCall takes an arbitrary AST expression and determines if it


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Previously the function that `ast.Inspect` ran to print debug info was simply inline. This PR creates a function `findAndDebug` which instead returns the closure, so the call to `ast.Inspect` can now just call `findAndDebug` and is a bit tidier

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if needed.
- [ ] I have updated the tests if needed.
